### PR TITLE
Allow multiple-policy processing

### DIFF
--- a/internal/mutate/mutate_test.go
+++ b/internal/mutate/mutate_test.go
@@ -639,7 +639,7 @@ func getMD5Hash(data []byte) string {
 
 func testPolicies() policies.Policies {
 	return policies.Policies{
-		Deployments: []*policies.Policy{
+		Deployments: []policies.Policy{
 			{
 				Namespace: "default",
 				Name:      "nginx-deployment",
@@ -648,7 +648,7 @@ func testPolicies() policies.Policies {
 				Type:      "env",
 			},
 		},
-		DaemonSets: []*policies.Policy{
+		DaemonSets: []policies.Policy{
 			{
 				Namespace: "test",
 				Name:      "nginx-daemonset",
@@ -657,7 +657,7 @@ func testPolicies() policies.Policies {
 				Type:      "env",
 			},
 		},
-		ConfigMaps: []*policies.Policy{
+		ConfigMaps: []policies.Policy{
 			{
 				Namespace: "default",
 				Name:      "example-configmap",

--- a/internal/policies/policies.go
+++ b/internal/policies/policies.go
@@ -6,9 +6,9 @@ import (
 )
 
 type Policies struct {
-	DaemonSets  []*Policy `json:"DaemonSets"`
-	Deployments []*Policy `json:"Deployments"`
-	ConfigMaps  []*Policy `json:"ConfigMaps"`
+	DaemonSets  []Policy `json:"DaemonSets"`
+	Deployments []Policy `json:"Deployments"`
+	ConfigMaps  []Policy `json:"ConfigMaps"`
 }
 
 type Policy struct {
@@ -44,32 +44,33 @@ func LoadPolicies(path string) (Policies, error) {
 	return policies, nil
 }
 
-func FindDeploymentPolicy(policies []*Policy, namespace string, name string, keyType string) (*Policy, error) {
+func FindDeploymentPolicy(policies []Policy, namespace string, name string, keyType string) []Policy {
+	var p []Policy
 	for _, v := range policies {
 		if v.Namespace == namespace && v.Name == name && v.Type == keyType {
-			return v, nil
+			p = append(p, v)
 		}
 	}
 
-	return nil, nil
+	return p
 }
 
-func FindDaemonSetPolicy(policies []*Policy, namespace string, name string, keyType string) (*Policy, error) {
+func FindDaemonSetPolicy(policies []Policy, namespace string, name string, keyType string) []Policy {
+	var p []Policy
 	for _, v := range policies {
 		if v.Namespace == namespace && v.Name == name && v.Type == keyType {
-			return v, nil
+			p = append(p, v)
 		}
 	}
-
-	return nil, nil
+	return p
 }
 
-func FindConfigMapPolicy(policies []*Policy, namespace string, name string, keyType string) (*Policy, error) {
+func FindConfigMapPolicy(policies []Policy, namespace string, name string) []Policy {
+	var p []Policy
 	for _, v := range policies {
 		if v.Namespace == namespace && v.Name == name {
-			return v, nil
+			p = append(p, v)
 		}
 	}
-
-	return nil, nil
+	return p
 }

--- a/internal/policies/policies.go
+++ b/internal/policies/policies.go
@@ -51,7 +51,6 @@ func FindDeploymentPolicy(policies []Policy, namespace string, name string, keyT
 			p = append(p, v)
 		}
 	}
-
 	return p
 }
 

--- a/internal/policies/policies_test.go
+++ b/internal/policies/policies_test.go
@@ -5,12 +5,6 @@ import (
 	"testing"
 )
 
-func TestDaemonSetPolicy(t *testing.T) {
-	policy, err := FindDaemonSetPolicy("test", "nginx-daemonset", "env")
-	_ = policy
-	_ = err
-}
-
 func TestPolicies(t *testing.T) {
 	rawJSON := `
 {


### PR DESCRIPTION
Currently only allows a single policy to match, changed over to an array of policies.