### PR TITLE
Injecting configuration data doesn't work on empty ConfigMaps

### DIFF
--- a/internal/mutate/mutate.go
+++ b/internal/mutate/mutate.go
@@ -151,7 +151,6 @@ func mutateConfigMap(request *admissionv1.AdmissionRequest, response *admissionv
 					Value: value,
 				})
 			}
-			configVar++
 		}
 	}
 

--- a/internal/mutate/mutate.go
+++ b/internal/mutate/mutate.go
@@ -121,7 +121,9 @@ func mutateConfigMap(request *admissionv1.AdmissionRequest, response *admissionv
 		}
 
 		found := false
+		configVar := 0
 		for key := range configMap.Data {
+			configVar++
 			if key == policy.Key {
 				patches = append(patches, PatchOperation{
 					Op:    "replace",
@@ -134,11 +136,22 @@ func mutateConfigMap(request *admissionv1.AdmissionRequest, response *admissionv
 		}
 
 		if !found {
-			patches = append(patches, PatchOperation{
-				Op:    "add",
-				Path:  fmt.Sprintf("/data/%s", policy.Key),
-				Value: value,
-			})
+			if configVar == 0 {
+				patches = append(patches, PatchOperation{
+					Op:   "add",
+					Path: "/data",
+					Value: map[string]string{
+						policy.Key: value,
+					},
+				})
+			} else {
+				patches = append(patches, PatchOperation{
+					Op:    "add",
+					Path:  fmt.Sprintf("/data/%s", policy.Key),
+					Value: value,
+				})
+			}
+			configVar++
 		}
 	}
 

--- a/internal/mutate/mutate.go
+++ b/internal/mutate/mutate.go
@@ -136,7 +136,7 @@ func mutateConfigMap(request *admissionv1.AdmissionRequest, response *admissionv
 		}
 
 		if !found {
-			if configVar == 0 {
+			if configVar == 0 && len(patches) == 0 {
 				patches = append(patches, PatchOperation{
 					Op:   "add",
 					Path: "/data",


### PR DESCRIPTION
The JSON patching for adding didn't work on ConfigMaps that were empty.  Updated the code to determine if it is empty and make the first add patch use a different add format.